### PR TITLE
Feature: Now handles re-emqueue with delay

### DIFF
--- a/lib/sidekiq_flow/errors.rb
+++ b/lib/sidekiq_flow/errors.rb
@@ -5,7 +5,7 @@ module SidekiqFlow
   class SkipTask < Error; end
   class RepeatTask < Error; end
 
-  class RepeatTaskLater < Error
+  class TryLater < Error
     attr_reader :delay_time
 
     def initialize(delay_time: delay_time)

--- a/lib/sidekiq_flow/errors.rb
+++ b/lib/sidekiq_flow/errors.rb
@@ -4,4 +4,12 @@ module SidekiqFlow
   class TaskUnstartable < Error; end
   class SkipTask < Error; end
   class RepeatTask < Error; end
+
+  class RepeatTaskLater < Error
+    attr_reader :delay_time
+
+    def initialize(delay_time: delay_time)
+      @delay_time = delay_time.to_i
+    end
+  end
 end

--- a/lib/sidekiq_flow/version.rb
+++ b/lib/sidekiq_flow/version.rb
@@ -1,3 +1,3 @@
 module SidekiqFlow
-  VERSION = "0.3.18"
+  VERSION = "0.3.19"
 end

--- a/lib/sidekiq_flow/worker.rb
+++ b/lib/sidekiq_flow/worker.rb
@@ -36,6 +36,8 @@ module SidekiqFlow
       TaskLogger.log(task.workflow_id, task.klass, :info, 'task skipped')
     rescue RepeatTask
       Client.enqueue_task(task, (Time.now + task.loop_interval).to_i)
+    rescue RepeatTaskLater => e
+      Client.enqueue_task(task, (Time.now + e.delay_time).to_i)
     rescue StandardError => e
       task.set_error_msg!(e.to_s)
       if task.no_retries?

--- a/lib/sidekiq_flow/worker.rb
+++ b/lib/sidekiq_flow/worker.rb
@@ -36,7 +36,7 @@ module SidekiqFlow
       TaskLogger.log(task.workflow_id, task.klass, :info, 'task skipped')
     rescue RepeatTask
       Client.enqueue_task(task, (Time.now + task.loop_interval).to_i)
-    rescue RepeatTaskLater => e
+    rescue TryLater => e
       Client.enqueue_task(task, (Time.now + e.delay_time).to_i)
     rescue StandardError => e
       task.set_error_msg!(e.to_s)

--- a/sidekiq_flow.gemspec
+++ b/sidekiq_flow.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "sprockets", "~> 3.5"
   spec.add_runtime_dependency "uglifier", "~> 4.1"
   spec.add_runtime_dependency "sass", "~> 3.5"
+  spec.add_runtime_dependency "timecop", "~> 0.9"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe 'workflow' do
       workflow = TestWorkflow.new(id: 123)
       SidekiqFlow::Client.start_workflow(workflow)
 
-      allow_any_instance_of(TestTask1).to receive(:perform) { raise SidekiqFlow::RepeatTaskLater.new(delay_time: 15.minutes) }
+      allow_any_instance_of(TestTask1).to receive(:perform) { raise SidekiqFlow::TryLater.new(delay_time: 15.minutes) }
       expect{SidekiqFlow::Worker.perform_one}.to change{Sidekiq::Worker.jobs.dig(0, 'at')}.to(first_job_at + 15.minutes.to_i)
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'fakeredis'
 require 'sidekiq/testing'
 require 'sidekiq_flow'
 require 'test_workflow'
+require 'timecop'
 
 redis = Redis.new(url: SidekiqFlow.configuration.redis_url)
 


### PR DESCRIPTION
This PR allows us to catch a specific exception (`RepeatTaskLater`) enabling us to re-enqueue the current task at a specific time. 