### PR TITLE
Remove circular argument warning

### DIFF
--- a/lib/sidekiq_flow/errors.rb
+++ b/lib/sidekiq_flow/errors.rb
@@ -8,7 +8,7 @@ module SidekiqFlow
   class TryLater < Error
     attr_reader :delay_time
 
-    def initialize(delay_time: delay_time)
+    def initialize(delay_time:)
       @delay_time = delay_time.to_i
     end
   end


### PR DESCRIPTION
Remove delay_time value from keyword arguments as it doesn't do anything and gives a warning.

Either set a default value, or just remove it (to make it a required param).