### PR TITLE
Add guard check to start_workflow

### DIFF
--- a/lib/sidekiq_flow/version.rb
+++ b/lib/sidekiq_flow/version.rb
@@ -1,3 +1,3 @@
 module SidekiqFlow
-  VERSION = "0.3.22"
+  VERSION = "0.3.23"
 end


### PR DESCRIPTION
* Sometimes workflows with the same id get triggered at the same time and results flaky results.