### PR TITLE
Add TriggerTaskManually error

### DIFF
--- a/lib/sidekiq_flow/errors.rb
+++ b/lib/sidekiq_flow/errors.rb
@@ -4,6 +4,7 @@ module SidekiqFlow
   class TaskUnstartable < Error; end
   class SkipTask < Error; end
   class RepeatTask < Error; end
+  class TriggerTaskManually < Error; end
 
   class TryLater < Error
     attr_reader :delay_time

--- a/lib/sidekiq_flow/version.rb
+++ b/lib/sidekiq_flow/version.rb
@@ -1,3 +1,3 @@
 module SidekiqFlow
-  VERSION = "0.3.28"
+  VERSION = "0.3.29"
 end


### PR DESCRIPTION
The purpose of this is add additional control flow on how a `SidekiqFlow::Task` is run inside a worker.
Sometimes there are scenarios where we just want the task to go back to it's initial state instead.

A specific scenario is this:

#### Customer buys 100eur worth of bitcoin and payment is done twice.

1. First payment (50eur)=> does a funding request workflow and trigger the fund operation task. Fund operation task cannot complete. We raise TriggerTaskManually here if not valid or any exception occured. (currently it's doing a SkipTask).

2. Second payment (50eur)=> does a funding request workflow and trigger the fund operation task. Fund operation is complete and go on to the next tasks.


