### PR TITLE
Store start & end timestamps to rebuild workflow_key

### DIFF
--- a/lib/sidekiq_flow/client.rb
+++ b/lib/sidekiq_flow/client.rb
@@ -166,7 +166,7 @@ module SidekiqFlow
 
       def already_started?(workflow_id)
         workflow_key = build_workflow_key_from_timestamps(workflow_id)
-        return workflow_key if workflow_key
+        return true if workflow_key
 
         # N+1 scan legacy behaviour
         key_pattern = already_started_workflow_key_pattern(workflow_id)
@@ -238,6 +238,8 @@ module SidekiqFlow
 
       def workflow_key_exists?(workflow_key)
         connection_pool.with do |redis|
+          # NOTE: Redis ~>4.2.5 modified exists to be a variadic function
+          #       and returns integers.
           redis.exists(workflow_key)
         end
       end

--- a/lib/sidekiq_flow/client.rb
+++ b/lib/sidekiq_flow/client.rb
@@ -229,7 +229,7 @@ module SidekiqFlow
                          "#{configuration.namespace}.#{workflow_id}_#{start_timestamp}_0"
                        end
         # sanity check find in case workflow key was already deleted
-        if workflow_key_exists?(workflow_key)
+        if workflow_key && workflow_key_exists?(workflow_key)
           workflow_key
         else
           nil

--- a/lib/sidekiq_flow/client.rb
+++ b/lib/sidekiq_flow/client.rb
@@ -239,8 +239,8 @@ module SidekiqFlow
       def workflow_key_exists?(workflow_key)
         connection_pool.with do |redis|
           # NOTE: Redis ~>4.2.5 modified exists to be a variadic function
-          #       and returns integers.
-          redis.exists(workflow_key)
+          #       and returns integers, so we use exists?.
+          redis.exists?(workflow_key)
         end
       end
     end

--- a/lib/sidekiq_flow/version.rb
+++ b/lib/sidekiq_flow/version.rb
@@ -1,3 +1,3 @@
 module SidekiqFlow
-  VERSION = "0.3.34"
+  VERSION = "0.3.35"
 end

--- a/sidekiq_flow.gemspec
+++ b/sidekiq_flow.gemspec
@@ -29,7 +29,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sidekiq", "~> 5.1"
+  spec.add_dependency "sidekiq", "< 5.2.8"
+  spec.add_dependency "redis", "~> 4.2.5"
   spec.add_dependency "activesupport", "~> 5.0"
   spec.add_runtime_dependency "sinatra", "~> 2.0"
   spec.add_runtime_dependency "thin", "~> 1.7"


### PR DESCRIPTION
This is a quick fix to go around the N+1 redis scan issue while waiting for rfc_006 PR to be merged.

The idea is:
1. store start_timestamp when starting workflow
2. store end_timestamp when workflow succeeds
3. build the workflow_key based on the stored timestamps (if it exists) and return that instead of doing the redis N+1 scan.

This new logic only applies to new workfflows.

For old workflows (with no start & end timestamps stored), will behave as is (redis n+1 scan) for compatibility.