### PR TITLE
Add inline attribute on task

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ By starting the workflow, we understand starting all tasks having no parents (`T
   * default is `['all_succeeded', {}]` - which means that all parents have to finish with success
   * other available rule: `['number_succeeded', {number: 2}]` - at least 2 parents succedeed
 
+* `inline`
+  * Sidekiq execution may be quite slow when we have a succession of tasks (~ 5s per task).
+  * So instead of enqueuing each children task, a task may directly perform a children task when it is set to inline.
+  * default is false.
+
 
 ## Externally triggered tasks
 When a task is defined with `start_date` equals `nil` (`TestTask.new(start_date: nil`), this means the task needs to be triggered from outside the workflow. Even `trigger_rule` condition is met, this task won't be started. To start this task we need to do this explicity:

--- a/lib/sidekiq_flow/task.rb
+++ b/lib/sidekiq_flow/task.rb
@@ -28,6 +28,7 @@ module SidekiqFlow
       @trigger_rule = attrs[:trigger_rule] || ['all_succeeded', {}]
       @params = attrs[:params] || {}
       @parents = attrs[:parents] || []
+      @inline = attrs[:inline] || false
       @error_msg = attrs[:error_msg]
     end
 

--- a/lib/sidekiq_flow/task.rb
+++ b/lib/sidekiq_flow/task.rb
@@ -9,7 +9,7 @@ module SidekiqFlow
 
     def self.attribute_names
       [
-        :start_date, :end_date, :loop_interval, :retries, :queue,
+        :start_date, :end_date, :loop_interval, :retries, :queue, :inline,
         :children, :status, :trigger_rule, :params, :error_msg
       ]
     end
@@ -119,6 +119,10 @@ module SidekiqFlow
 
     def auto_succeed?
       false
+    end
+
+    def inline?
+      @inline == true
     end
 
     def set_workflow_data!(workflow, workflow_params)

--- a/lib/sidekiq_flow/version.rb
+++ b/lib/sidekiq_flow/version.rb
@@ -1,3 +1,3 @@
 module SidekiqFlow
-  VERSION = "0.3.39"
+  VERSION = "0.3.40"
 end


### PR DESCRIPTION
Cf README.

Allow a payment to be fully processed in a second instead of ~ 30s, same for operation execution.
This is also a prerequisite to improve trading engine.

:warning: One issue with this method is in case of exception, it will be the root task which will be retried instead of the child, it is not easy to fix it / mess with Sidekiq internal code, but this is not a real issue since root task is supposed to be reentrant and auto succeeded.