### PR TITLE
[MISC] Add docker-compose.yml and fix flaky specs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Use the official Ruby image as a parent image
+FROM ruby:3.1
+
+# Set environment variables to avoid warnings during installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install Node.js 20
+RUN curl -sL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh \
+    && bash nodesource_setup.sh \
+    && apt-get install -y nodejs \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* nodesource_setup.sh
+
+# Set the working directory inside the container
+WORKDIR /app
+
+CMD ["tail", "-f", "/dev/null"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Ruby image as a parent image
-FROM ruby:3.1
+FROM ruby:3.2
 
 # Set environment variables to avoid warnings during installation
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  sidekiq_flow:
+    build:
+      context: '.'
+      dockerfile: Dockerfile
+    volumes:
+      - .:/app
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:6.2.6-alpine
+    command: redis-server --requirepass password
+    expose:
+      - 6379

--- a/lib/sidekiq_flow/configuration.rb
+++ b/lib/sidekiq_flow/configuration.rb
@@ -10,7 +10,7 @@ module SidekiqFlow
                   :redis
 
     def initialize
-      @redis_url = 'redis://localhost:6379'
+      @redis_url = 'redis://:password@redis:6379'
       @concurrency = 10
       @namespace = 'workflows'
       @queue = 'default'

--- a/lib/sidekiq_flow/version.rb
+++ b/lib/sidekiq_flow/version.rb
@@ -1,3 +1,3 @@
 module SidekiqFlow
-  VERSION = "0.3.43"
+  VERSION = "0.3.45"
 end

--- a/lib/sidekiq_flow/version.rb
+++ b/lib/sidekiq_flow/version.rb
@@ -1,3 +1,3 @@
 module SidekiqFlow
-  VERSION = "0.3.42"
+  VERSION = "0.3.43"
 end

--- a/spec/sidekiq_flow/client_spec.rb
+++ b/spec/sidekiq_flow/client_spec.rb
@@ -251,10 +251,12 @@ RSpec.describe SidekiqFlow::Client do
       end
 
       it 'should override the existing stored workflow' do
-        hash1 = redis.hgetall(redis.keys.last)
+        key = redis.keys.detect { |element| element.include?('_0') }
+
+        hash1 = redis.hgetall(key)
         workflow.clear_branch!('TestTask1')
         subject
-        hash2 = redis.hgetall(redis.keys.last)
+        hash2 = redis.hgetall(key)
 
         expect(hash1).not_to eq(hash2)
       end


### PR DESCRIPTION
### Summary

  - Add Docker and Docker Compose configuration for development environment
  - Update default Redis configuration to work with containerized Redis
  - Fix integration specs to handle parallel test execution
  - Bump version from 0.3.42 to 0.3.45

### Changes

**Docker Infrastructure:**
  - Add Dockerfile with Ruby 3.2 and Node.js 20 setup
  - Add docker-compose.yml with sidekiq_flow service and Redis 6.2.6 container
  - Redis container configured with password authentication (simulates monolith behavior)

**Configuration:**
  - Update default Redis URL to use containerized Redis with password auth (redis://:password@redis:6379)

**Test Improvements:**
  - Add to_s method to SidekiqFlow::Task for better test output
  - Replace status array assertions with match_array to handle parallel execution order
  - Fix flaky client spec by explicitly selecting the correct Redis key