### PR TITLE
Improve start_workflow by optimizing already_started? method

### DIFF
--- a/lib/sidekiq_flow/client.rb
+++ b/lib/sidekiq_flow/client.rb
@@ -172,17 +172,7 @@ module SidekiqFlow
       end
 
       def already_started?(workflow_id)
-        workflow_key = build_workflow_key_from_timestamps(workflow_id)
-        return true if workflow_key
-
-        # N+1 scan legacy behaviour
-        key_pattern = already_started_workflow_key_pattern(workflow_id)
-
-        find_first(key_pattern).present?
-      end
-
-      def already_started_workflow_key_pattern(workflow_id)
-        "#{configuration.namespace}.#{workflow_id}_*_0"
+        build_workflow_key_from_timestamps(workflow_id).present?
       end
 
       def already_succeeded?(workflow_id, workflow_key)


### PR DESCRIPTION
Simplify already_started? method by just returning false directly and remove legacy behavior of doing N+1 redis scans.