### PR TITLE
Raise WorkflowKeyNotFound instead of doing redis scan

### DIFF
--- a/lib/sidekiq_flow/errors.rb
+++ b/lib/sidekiq_flow/errors.rb
@@ -1,6 +1,7 @@
 module SidekiqFlow
   class Error < StandardError; end
   class WorkflowNotFound < Error; end
+  class WorkflowKeyNotFound < Error; end
   class TaskUnstartable < Error; end
   class SkipTask < Error; end
   class RepeatTask < Error; end


### PR DESCRIPTION
**Summary**
  - Removed legacy N+1 Redis SCAN fallback from find_workflow_key method
  - Added WorkflowKeyNotFound exception to provide clear error when workflow keys cannot be found
  - Deleted unused find_first method that performed expensive sequential Redis SCAN operations

**Context**
The find_workflow_key method previously had a fallback that used Redis SCAN to find workflow keys for workflows created before the timestamp optimization was introduced (2+ years ago). Since all workflows now follow the timestamp pattern via store_start_timestamp, this legacy fallback path is no longer needed.

**Performance Impact**
  This eliminates potential N+1 Redis SCAN operations, improving performance by:
  - Removing sequential SCAN loop that could iterate multiple times
  - Failing fast with explicit error instead of expensive key pattern matching
  - Reducing Redis round trips for workflow lookups