### PR TITLE
[DEVOPS-977] Extract to KeyManager class and delegate

### DIFF
--- a/lib/sidekiq_flow.rb
+++ b/lib/sidekiq_flow.rb
@@ -9,6 +9,7 @@ require 'uglifier'
 
 require "sidekiq_flow/version"
 require "sidekiq_flow/configuration"
+require "sidekiq_flow/key_manager"
 require "sidekiq_flow/client"
 require "sidekiq_flow/model"
 require "sidekiq_flow/task"

--- a/lib/sidekiq_flow/client.rb
+++ b/lib/sidekiq_flow/client.rb
@@ -57,7 +57,13 @@ module SidekiqFlow
       # @param initial [Boolean] whether this is the first time storing this workflow
       # @return [void]
       def store_workflow(workflow, initial = false)
-        workflow_key = initial ? generate_initial_workflow_key(workflow.id) : find_workflow_key(workflow.id)
+        workflow_key = if initial
+                         timestamp = Time.now.to_i
+                         store_start_timestamp(workflow.id, timestamp)
+                         generate_initial_workflow_key(workflow.id, timestamp)
+                       else
+                         find_workflow_key(workflow.id)
+                       end
 
         if workflow_key.blank?
           logger.error("Workflow[#{workflow.id}] Cannot store workflow: workflow_key not found")
@@ -77,7 +83,7 @@ module SidekiqFlow
       # @return [void]
       def store_task(task)
         connection_pool.with do |redis|
-          workflow_key = find_workflow_key(task.workflow_id)
+          workflow_key = find_workflow_key(task.workflow_id, redis)
 
           if workflow_key.blank?
             logger.error("Workflow[#{task.workflow_id}][#{task.klass}] Cannot store task: workflow_key not found")
@@ -97,7 +103,7 @@ module SidekiqFlow
       # @raise [WorkflowNotFound] if the workflow doesn't exist in Redis
       def find_workflow(workflow_id)
         connection_pool.with do |redis|
-          workflow_key = find_workflow_key(workflow_id)
+          workflow_key = find_workflow_key(workflow_id, redis)
 
           if workflow_key.blank?
             logger.error("Workflow[#{workflow_id}] Cannot find workflow: workflow_key not found")
@@ -144,7 +150,9 @@ module SidekiqFlow
         return if workflow_keys.empty?
 
         workflow_ids = workflow_keys.map { |key| key.match(/#{configuration.namespace}\.(\d+)_/)[1] }
-        timestamp_keys = workflow_ids.flat_map { |id| ["#{timestamp_namespace}.#{id}.start", "#{timestamp_namespace}.#{id}.end"] }
+        timestamp_keys = workflow_ids.flat_map do |id|
+          ["#{timestamp_namespace}.#{id}.start", "#{timestamp_namespace}.#{id}.end"]
+        end
 
         connection_pool.with do |redis|
           redis.pipelined do |pipeline|
@@ -192,21 +200,10 @@ module SidekiqFlow
 
       # Looks up the Redis key for a workflow using the lookup hash with fallback to legacy method
       # @param workflow_id [String, Integer] the workflow identifier
+      # @param redis [Redis, nil] optional Redis connection (avoids nested pool usage)
       # @return [String, nil] the Redis key or nil if not found
-      def find_workflow_key(workflow_id)
-        # Try new lookup hash first
-        workflow_key = lookup_workflow_key(workflow_id)
-        return workflow_key if workflow_key.present?
-
-        # Fallback to old timestamp-based lookup for existing workflows
-        workflow_key = build_workflow_key_from_timestamps(workflow_id)
-
-        # If found via fallback, migrate it to the new lookup hash
-        if workflow_key.present?
-          store_workflow_key(workflow_id, workflow_key)
-        end
-
-        workflow_key
+      def find_workflow_key(workflow_id, redis = nil)
+        key_manager.find_workflow_key(workflow_id, redis)
       end
 
       # Changes the Sidekiq queue for a specific task
@@ -244,17 +241,13 @@ module SidekiqFlow
       end
 
       # Creates the initial Redis key for a new workflow and stores it in the lookup hash
+      # @deprecated Use key_manager.generate_initial_workflow_key instead
       # @param workflow_id [String, Integer] the workflow identifier
+      # @param timestamp [Integer] the Unix timestamp
+      # @param redis [Redis, nil] optional Redis connection (avoids nested pool usage)
       # @return [String] the generated workflow key
-      def generate_initial_workflow_key(workflow_id)
-        timestamp = Time.now.to_i
-
-        store_start_timestamp(workflow_id, timestamp)
-
-        workflow_key = "#{configuration.namespace}.#{workflow_id}_#{timestamp}_0"
-        store_workflow_key(workflow_id, workflow_key)
-
-        workflow_key
+      def generate_initial_workflow_key(workflow_id, timestamp, redis = nil)
+        key_manager.generate_initial_workflow_key(workflow_id, timestamp, redis)
       end
 
       # Checks if all tasks in the workflow have succeeded
@@ -292,15 +285,17 @@ module SidekiqFlow
       end
 
       # Returns the Redis pattern to match all workflow keys
+      # @deprecated Use key_manager.workflow_key_pattern instead
       # @return [String] the pattern for scanning workflow keys
       def workflow_key_pattern
-        "#{configuration.namespace}.*"
+        key_manager.workflow_key_pattern
       end
 
       # Returns the Redis pattern to match only completed workflow keys
+      # @deprecated Use key_manager.succeeded_workflow_key_pattern instead
       # @return [String] the pattern for scanning succeeded workflow keys
       def succeeded_workflow_key_pattern
-        "#{configuration.namespace}.*_*_[^0]*"
+        key_manager.succeeded_workflow_key_pattern
       end
 
       # Checks if a workflow has been started by looking for its key
@@ -319,9 +314,10 @@ module SidekiqFlow
       end
 
       # Returns the Redis namespace for workflow timestamp keys
+      # @deprecated Use key_manager.timestamp_namespace instead
       # @return [String] the timestamp namespace
       def timestamp_namespace
-        'workflow-timestamps'
+        key_manager.timestamp_namespace
       end
 
       # Stores the workflow start timestamp in Redis
@@ -335,75 +331,64 @@ module SidekiqFlow
       end
 
       # Returns the Redis namespace for the workflow key lookup hash
+      # @deprecated Use key_manager.workflow_keys_namespace instead
       # @return [String] the workflow keys namespace
       def workflow_keys_namespace
-        'workflow-keys'
+        key_manager.workflow_keys_namespace
       end
 
       # Retrieves a workflow key from the lookup hash
+      # @deprecated Use key_manager.lookup_workflow_key instead
       # @param workflow_id [String, Integer] the workflow identifier
+      # @param redis [Redis, nil] optional Redis connection (avoids nested pool usage)
       # @return [String, nil] the workflow key or nil if not found
-      def lookup_workflow_key(workflow_id)
-        connection_pool.with do |redis|
-          redis.hget(workflow_keys_namespace, workflow_id)
-        end
+      def lookup_workflow_key(workflow_id, redis = nil)
+        key_manager.lookup_workflow_key(workflow_id, redis)
       end
 
       # Stores a workflow key in the lookup hash for fast retrieval
+      # @deprecated Use key_manager.store_workflow_key instead
       # @param workflow_id [String, Integer] the workflow identifier
       # @param workflow_key [String] the Redis key to store
+      # @param redis [Redis, nil] optional Redis connection (avoids nested pool usage)
       # @return [void]
-      def store_workflow_key(workflow_id, workflow_key)
-        connection_pool.with do |redis|
-          redis.hset(workflow_keys_namespace, workflow_id, workflow_key)
-        end
+      def store_workflow_key(workflow_id, workflow_key, redis = nil)
+        key_manager.store_workflow_key(workflow_id, workflow_key, redis)
       end
 
       # Removes a workflow key from the lookup hash
+      # @deprecated Use key_manager.delete_workflow_key instead
       # @param workflow_id [String, Integer] the workflow identifier
+      # @param redis [Redis, nil] optional Redis connection (avoids nested pool usage)
       # @return [void]
-      def delete_workflow_key(workflow_id)
-        connection_pool.with do |redis|
-          redis.hdel(workflow_keys_namespace, workflow_id)
-        end
+      def delete_workflow_key(workflow_id, redis = nil)
+        key_manager.delete_workflow_key(workflow_id, redis)
       end
 
       # Legacy method that rebuilds a workflow key from timestamp keys (fallback for old workflows)
+      # @deprecated Use key_manager.build_workflow_key_from_timestamps instead
       # @param workflow_id [String, Integer] the workflow identifier
+      # @param redis [Redis, nil] optional Redis connection (avoids nested pool usage)
       # @return [String, nil] the reconstructed workflow key or nil if timestamps missing
-      def build_workflow_key_from_timestamps(workflow_id)
-        start_timestamp, end_timestamp = connection_pool.with do |redis|
-          redis.pipelined do |pipeline|
-            pipeline.get("#{timestamp_namespace}.#{workflow_id}.start")
-            pipeline.get("#{timestamp_namespace}.#{workflow_id}.end")
-          end
-        end
-
-        return nil unless start_timestamp
-
-        workflow_key = if end_timestamp && start_timestamp
-                         "#{configuration.namespace}.#{workflow_id}_#{start_timestamp}_#{end_timestamp}"
-                       elsif start_timestamp
-                         "#{configuration.namespace}.#{workflow_id}_#{start_timestamp}_0"
-                       end
-
-        # Verify the workflow data actually exists
-        unless workflow_key_exists?(workflow_key)
-          logger.warn("Workflow[#{workflow_id}] Timestamps exist but workflow data missing (key: #{workflow_key})")
-          return nil
-        end
-
-        workflow_key
+      def build_workflow_key_from_timestamps(workflow_id, redis = nil)
+        key_manager.build_workflow_key_from_timestamps(workflow_id, redis)
       end
 
       # Checks if a workflow key exists in Redis
+      # @deprecated Use key_manager.workflow_key_exists? instead
       # @param workflow_key [String] the Redis key to check
+      # @param redis [Redis, nil] optional Redis connection (avoids nested pool usage)
       # @return [Boolean] true if the key exists
-      def workflow_key_exists?(workflow_key)
-        connection_pool.with do |redis|
-          redis.exists?(workflow_key)
-        end
+      def workflow_key_exists?(workflow_key, redis = nil)
+        key_manager.workflow_key_exists?(workflow_key, redis)
       end
+
+      # Returns the key manager instance for workflow key operations
+      # @return [KeyManager] the key manager instance
+      def key_manager
+        @key_manager ||= KeyManager.new(connection_pool, configuration)
+      end
+
     end
   end
 end

--- a/lib/sidekiq_flow/client.rb
+++ b/lib/sidekiq_flow/client.rb
@@ -388,7 +388,6 @@ module SidekiqFlow
       def key_manager
         @key_manager ||= KeyManager.new(connection_pool, configuration)
       end
-
     end
   end
 end

--- a/lib/sidekiq_flow/key_manager.rb
+++ b/lib/sidekiq_flow/key_manager.rb
@@ -1,0 +1,159 @@
+module SidekiqFlow
+  # Manages Redis key generation, lookup, and storage for workflows
+  class KeyManager
+    attr_reader :connection_pool, :configuration
+
+    def initialize(connection_pool, configuration)
+      @connection_pool = connection_pool
+      @configuration = configuration
+    end
+
+    # Creates the initial Redis key for a new workflow and stores it in the lookup hash
+    # @param workflow_id [String, Integer] the workflow identifier
+    # @param timestamp [Integer] the Unix timestamp
+    # @param redis [Redis, nil] optional Redis connection (avoids nested pool usage)
+    # @return [String] the generated workflow key
+    def generate_initial_workflow_key(workflow_id, timestamp, redis = nil)
+      workflow_key = "#{configuration.namespace}.#{workflow_id}_#{timestamp}_0"
+      store_workflow_key(workflow_id, workflow_key, redis)
+      workflow_key
+    end
+
+    # Looks up the Redis key for a workflow using the lookup hash with fallback to legacy method
+    # @param workflow_id [String, Integer] the workflow identifier
+    # @param redis [Redis, nil] optional Redis connection (avoids nested pool usage)
+    # @return [String, nil] the Redis key or nil if not found
+    def find_workflow_key(workflow_id, redis = nil)
+      # Try new lookup hash first
+      workflow_key = lookup_workflow_key(workflow_id, redis)
+      return workflow_key if workflow_key.present?
+
+      # Fallback to old timestamp-based lookup for existing workflows
+      workflow_key = build_workflow_key_from_timestamps(workflow_id, redis)
+
+      # If found via fallback, migrate it to the new lookup hash
+      if workflow_key.present?
+        store_workflow_key(workflow_id, workflow_key, redis)
+      end
+
+      workflow_key
+    end
+
+    # Retrieves a workflow key from the lookup hash
+    # @param workflow_id [String, Integer] the workflow identifier
+    # @param redis [Redis, nil] optional Redis connection (avoids nested pool usage)
+    # @return [String, nil] the workflow key or nil if not found
+    def lookup_workflow_key(workflow_id, redis = nil)
+      if redis
+        redis.hget(workflow_keys_namespace, workflow_id)
+      else
+        connection_pool.with do |conn|
+          conn.hget(workflow_keys_namespace, workflow_id)
+        end
+      end
+    end
+
+    # Stores a workflow key in the lookup hash for fast retrieval
+    # @param workflow_id [String, Integer] the workflow identifier
+    # @param workflow_key [String] the Redis key to store
+    # @param redis [Redis, nil] optional Redis connection (avoids nested pool usage)
+    # @return [void]
+    def store_workflow_key(workflow_id, workflow_key, redis = nil)
+      if redis
+        redis.hset(workflow_keys_namespace, workflow_id, workflow_key)
+      else
+        connection_pool.with do |conn|
+          conn.hset(workflow_keys_namespace, workflow_id, workflow_key)
+        end
+      end
+    end
+
+    # Removes a workflow key from the lookup hash
+    # @param workflow_id [String, Integer] the workflow identifier
+    # @param redis [Redis, nil] optional Redis connection (avoids nested pool usage)
+    # @return [void]
+    def delete_workflow_key(workflow_id, redis = nil)
+      if redis
+        redis.hdel(workflow_keys_namespace, workflow_id)
+      else
+        connection_pool.with do |conn|
+          conn.hdel(workflow_keys_namespace, workflow_id)
+        end
+      end
+    end
+
+    # Legacy method that rebuilds a workflow key from timestamp keys (fallback for old workflows)
+    # @param workflow_id [String, Integer] the workflow identifier
+    # @param redis [Redis, nil] optional Redis connection (avoids nested pool usage)
+    # @return [String, nil] the reconstructed workflow key or nil if timestamps missing
+    def build_workflow_key_from_timestamps(workflow_id, redis = nil)
+      start_timestamp, end_timestamp = if redis
+                                         redis.pipelined do |pipeline|
+                                           pipeline.get("#{timestamp_namespace}.#{workflow_id}.start")
+                                           pipeline.get("#{timestamp_namespace}.#{workflow_id}.end")
+                                         end
+                                       else
+                                         connection_pool.with do |conn|
+                                           conn.pipelined do |pipeline|
+                                             pipeline.get("#{timestamp_namespace}.#{workflow_id}.start")
+                                             pipeline.get("#{timestamp_namespace}.#{workflow_id}.end")
+                                           end
+                                         end
+                                       end
+
+      return nil unless start_timestamp
+
+      workflow_key = if end_timestamp && start_timestamp
+                       "#{configuration.namespace}.#{workflow_id}_#{start_timestamp}_#{end_timestamp}"
+                     elsif start_timestamp
+                       "#{configuration.namespace}.#{workflow_id}_#{start_timestamp}_0"
+                     end
+
+      # Verify the workflow data actually exists
+      unless workflow_key_exists?(workflow_key, redis)
+        configuration.logger.warn("Workflow[#{workflow_id}] Timestamps exist but workflow data missing (key: #{workflow_key})")
+        return nil
+      end
+
+      workflow_key
+    end
+
+    # Checks if a workflow key exists in Redis
+    # @param workflow_key [String] the Redis key to check
+    # @param redis [Redis, nil] optional Redis connection (avoids nested pool usage)
+    # @return [Boolean] true if the key exists
+    def workflow_key_exists?(workflow_key, redis = nil)
+      if redis
+        redis.exists?(workflow_key)
+      else
+        connection_pool.with do |conn|
+          conn.exists?(workflow_key)
+        end
+      end
+    end
+
+    # Returns the Redis namespace for the workflow key lookup hash
+    # @return [String] the workflow keys namespace
+    def workflow_keys_namespace
+      'workflow-keys'
+    end
+
+    # Returns the Redis namespace for workflow timestamp keys
+    # @return [String] the timestamp namespace
+    def timestamp_namespace
+      'workflow-timestamps'
+    end
+
+    # Returns the Redis pattern to match all workflow keys
+    # @return [String] the pattern for scanning workflow keys
+    def workflow_key_pattern
+      "#{configuration.namespace}.*"
+    end
+
+    # Returns the Redis pattern to match only completed workflow keys
+    # @return [String] the pattern for scanning succeeded workflow keys
+    def succeeded_workflow_key_pattern
+      "#{configuration.namespace}.*_*_[^0]*"
+    end
+  end
+end

--- a/lib/sidekiq_flow/version.rb
+++ b/lib/sidekiq_flow/version.rb
@@ -1,3 +1,3 @@
 module SidekiqFlow
-  VERSION = "0.3.46"
+  VERSION = "0.3.47"
 end

--- a/spec/sidekiq_flow/key_manager_spec.rb
+++ b/spec/sidekiq_flow/key_manager_spec.rb
@@ -1,0 +1,400 @@
+require 'spec_helper'
+
+RSpec.describe SidekiqFlow::KeyManager do
+  let(:connection_pool) { SidekiqFlow::Client.connection_pool }
+  let(:configuration) { SidekiqFlow.configuration }
+  let(:key_manager) { described_class.new(connection_pool, configuration) }
+  let(:workflow_id) { 123 }
+  let(:redis) { $redis }
+
+  before do
+    redis.flushdb
+  end
+
+  describe '#generate_initial_workflow_key' do
+    let(:timestamp) { 1234567890 }
+
+    context 'without redis connection parameter' do
+      subject { key_manager.generate_initial_workflow_key(workflow_id, timestamp) }
+
+      it 'should generate correct key format' do
+        expect(subject).to eq("#{configuration.namespace}.#{workflow_id}_#{timestamp}_0")
+      end
+
+      it 'should store key in workflow-keys hash' do
+        result = subject
+        expect(redis.hget('workflow-keys', workflow_id)).to eq(result)
+      end
+    end
+
+    context 'with redis connection parameter (avoids nested pool)' do
+      subject { key_manager.generate_initial_workflow_key(workflow_id, timestamp, redis) }
+
+      it 'should generate correct key format' do
+        expect(subject).to eq("#{configuration.namespace}.#{workflow_id}_#{timestamp}_0")
+      end
+
+      it 'should store key in workflow-keys hash' do
+        result = subject
+        expect(redis.hget('workflow-keys', workflow_id)).to eq(result)
+      end
+
+      it 'should not fetch from connection pool' do
+        expect(connection_pool).not_to receive(:with)
+        subject
+      end
+    end
+  end
+
+  describe '#find_workflow_key' do
+    context 'without redis connection parameter' do
+      subject { key_manager.find_workflow_key(workflow_id) }
+
+      context 'when key exists in lookup hash' do
+        let(:workflow_key) { "#{configuration.namespace}.#{workflow_id}_1234567890_0" }
+
+        before do
+          redis.hset('workflow-keys', workflow_id, workflow_key)
+        end
+
+        it 'should return the workflow key' do
+          expect(subject).to eq(workflow_key)
+        end
+      end
+
+      context 'when key does not exist in lookup hash' do
+        context 'but timestamps exist (legacy workflow)' do
+          let(:start_timestamp) { '1234567890' }
+          let(:expected_key) { "#{configuration.namespace}.#{workflow_id}_#{start_timestamp}_0" }
+
+          before do
+            redis.set("workflow-timestamps.#{workflow_id}.start", start_timestamp)
+            redis.hset(expected_key, 'klass', 'TestWorkflow')
+          end
+
+          it 'should find key via timestamp fallback' do
+            expect(subject).to eq(expected_key)
+          end
+
+          it 'should migrate key to lookup hash' do
+            subject
+            expect(redis.hget('workflow-keys', workflow_id)).to eq(expected_key)
+          end
+        end
+
+        context 'and no timestamps exist' do
+          it 'should return nil' do
+            expect(subject).to be_nil
+          end
+        end
+
+        context 'timestamps exist but workflow data missing' do
+          before do
+            redis.set("workflow-timestamps.#{workflow_id}.start", '1234567890')
+          end
+
+          it 'should return nil' do
+            expect(subject).to be_nil
+          end
+
+          it 'should log warning' do
+            expect(configuration.logger).to receive(:warn).with(/Timestamps exist but workflow data missing/)
+            subject
+          end
+        end
+      end
+    end
+
+    context 'with redis connection parameter (avoids nested pool)' do
+      subject { key_manager.find_workflow_key(workflow_id, redis) }
+
+      context 'when key exists in lookup hash' do
+        let(:workflow_key) { "#{configuration.namespace}.#{workflow_id}_1234567890_0" }
+
+        before do
+          redis.hset('workflow-keys', workflow_id, workflow_key)
+        end
+
+        it 'should return the workflow key' do
+          expect(subject).to eq(workflow_key)
+        end
+
+        it 'should not fetch from connection pool' do
+          expect(connection_pool).not_to receive(:with)
+          subject
+        end
+      end
+
+      context 'when key does not exist but timestamps exist' do
+        let(:start_timestamp) { '1234567890' }
+        let(:expected_key) { "#{configuration.namespace}.#{workflow_id}_#{start_timestamp}_0" }
+
+        before do
+          redis.set("workflow-timestamps.#{workflow_id}.start", start_timestamp)
+          redis.hset(expected_key, 'klass', 'TestWorkflow')
+        end
+
+        it 'should find key via timestamp fallback without using pool' do
+          expect(connection_pool).not_to receive(:with)
+          expect(subject).to eq(expected_key)
+        end
+      end
+    end
+  end
+
+  describe '#lookup_workflow_key' do
+    context 'without redis connection parameter' do
+      subject { key_manager.lookup_workflow_key(workflow_id) }
+
+      context 'when key exists in hash' do
+        let(:workflow_key) { "#{configuration.namespace}.#{workflow_id}_1234567890_0" }
+
+        before do
+          redis.hset('workflow-keys', workflow_id, workflow_key)
+        end
+
+        it 'should return the workflow key' do
+          expect(subject).to eq(workflow_key)
+        end
+      end
+
+      context 'when key does not exist' do
+        it 'should return nil' do
+          expect(subject).to be_nil
+        end
+      end
+    end
+
+    context 'with redis connection parameter (avoids nested pool)' do
+      subject { key_manager.lookup_workflow_key(workflow_id, redis) }
+
+      context 'when key exists in hash' do
+        let(:workflow_key) { "#{configuration.namespace}.#{workflow_id}_1234567890_0" }
+
+        before do
+          redis.hset('workflow-keys', workflow_id, workflow_key)
+        end
+
+        it 'should return the workflow key' do
+          expect(subject).to eq(workflow_key)
+        end
+
+        it 'should not fetch from connection pool' do
+          expect(connection_pool).not_to receive(:with)
+          subject
+        end
+      end
+    end
+  end
+
+  describe '#store_workflow_key' do
+    let(:workflow_key) { "#{configuration.namespace}.#{workflow_id}_1234567890_0" }
+
+    context 'without redis connection parameter' do
+      subject { key_manager.store_workflow_key(workflow_id, workflow_key) }
+
+      it 'should store key in workflow-keys hash' do
+        subject
+        expect(redis.hget('workflow-keys', workflow_id)).to eq(workflow_key)
+      end
+    end
+
+    context 'with redis connection parameter (avoids nested pool)' do
+      subject { key_manager.store_workflow_key(workflow_id, workflow_key, redis) }
+
+      it 'should store key in workflow-keys hash' do
+        subject
+        expect(redis.hget('workflow-keys', workflow_id)).to eq(workflow_key)
+      end
+
+      it 'should not fetch from connection pool' do
+        expect(connection_pool).not_to receive(:with)
+        subject
+      end
+    end
+  end
+
+  describe '#delete_workflow_key' do
+    let(:workflow_key) { "#{configuration.namespace}.#{workflow_id}_1234567890_0" }
+
+    before do
+      redis.hset('workflow-keys', workflow_id, workflow_key)
+    end
+
+    context 'without redis connection parameter' do
+      subject { key_manager.delete_workflow_key(workflow_id) }
+
+      it 'should remove key from workflow-keys hash' do
+        subject
+        expect(redis.hget('workflow-keys', workflow_id)).to be_nil
+      end
+    end
+
+    context 'with redis connection parameter (avoids nested pool)' do
+      subject { key_manager.delete_workflow_key(workflow_id, redis) }
+
+      it 'should remove key from workflow-keys hash' do
+        subject
+        expect(redis.hget('workflow-keys', workflow_id)).to be_nil
+      end
+
+      it 'should not fetch from connection pool' do
+        expect(connection_pool).not_to receive(:with)
+        subject
+      end
+    end
+  end
+
+  describe '#build_workflow_key_from_timestamps' do
+    context 'without redis connection parameter' do
+      subject { key_manager.build_workflow_key_from_timestamps(workflow_id) }
+
+      context 'with start timestamp only (in-progress workflow)' do
+        let(:start_timestamp) { '1234567890' }
+        let(:expected_key) { "#{configuration.namespace}.#{workflow_id}_#{start_timestamp}_0" }
+
+        before do
+          redis.set("workflow-timestamps.#{workflow_id}.start", start_timestamp)
+          redis.hset(expected_key, 'klass', 'TestWorkflow')
+        end
+
+        it 'should return correct key format' do
+          expect(subject).to eq(expected_key)
+        end
+      end
+
+      context 'with start and end timestamps (completed workflow)' do
+        let(:start_timestamp) { '1234567890' }
+        let(:end_timestamp) { '1234567900' }
+        let(:expected_key) { "#{configuration.namespace}.#{workflow_id}_#{start_timestamp}_#{end_timestamp}" }
+
+        before do
+          redis.set("workflow-timestamps.#{workflow_id}.start", start_timestamp)
+          redis.set("workflow-timestamps.#{workflow_id}.end", end_timestamp)
+          redis.hset(expected_key, 'klass', 'TestWorkflow')
+        end
+
+        it 'should return correct key format' do
+          expect(subject).to eq(expected_key)
+        end
+      end
+
+      context 'with no timestamps' do
+        it 'should return nil' do
+          expect(subject).to be_nil
+        end
+      end
+
+      context 'timestamps exist but workflow data missing' do
+        before do
+          redis.set("workflow-timestamps.#{workflow_id}.start", '1234567890')
+        end
+
+        it 'should return nil' do
+          expect(subject).to be_nil
+        end
+
+        it 'should log warning' do
+          expect(configuration.logger).to receive(:warn).with(/Timestamps exist but workflow data missing/)
+          subject
+        end
+      end
+    end
+
+    context 'with redis connection parameter (avoids nested pool)' do
+      subject { key_manager.build_workflow_key_from_timestamps(workflow_id, redis) }
+
+      context 'with start timestamp only' do
+        let(:start_timestamp) { '1234567890' }
+        let(:expected_key) { "#{configuration.namespace}.#{workflow_id}_#{start_timestamp}_0" }
+
+        before do
+          redis.set("workflow-timestamps.#{workflow_id}.start", start_timestamp)
+          redis.hset(expected_key, 'klass', 'TestWorkflow')
+        end
+
+        it 'should return correct key format without using pool' do
+          expect(connection_pool).not_to receive(:with)
+          expect(subject).to eq(expected_key)
+        end
+      end
+    end
+  end
+
+  describe '#workflow_key_exists?' do
+    let(:workflow_key) { "#{configuration.namespace}.#{workflow_id}_1234567890_0" }
+
+    context 'without redis connection parameter' do
+      subject { key_manager.workflow_key_exists?(workflow_key) }
+
+      context 'when key exists' do
+        before do
+          redis.hset(workflow_key, 'klass', 'TestWorkflow')
+        end
+
+        it 'should return true' do
+          expect(subject).to be true
+        end
+      end
+
+      context 'when key does not exist' do
+        it 'should return false' do
+          expect(subject).to be false
+        end
+      end
+    end
+
+    context 'with redis connection parameter (avoids nested pool)' do
+      subject { key_manager.workflow_key_exists?(workflow_key, redis) }
+
+      context 'when key exists' do
+        before do
+          redis.hset(workflow_key, 'klass', 'TestWorkflow')
+        end
+
+        it 'should return true' do
+          expect(subject).to be true
+        end
+
+        it 'should not fetch from connection pool' do
+          expect(connection_pool).not_to receive(:with)
+          subject
+        end
+      end
+    end
+  end
+
+  describe '#workflow_keys_namespace' do
+    it 'should return correct namespace' do
+      expect(key_manager.workflow_keys_namespace).to eq('workflow-keys')
+    end
+  end
+
+  describe '#timestamp_namespace' do
+    it 'should return correct namespace' do
+      expect(key_manager.timestamp_namespace).to eq('workflow-timestamps')
+    end
+  end
+
+  describe '#workflow_key_pattern' do
+    it 'should return correct pattern' do
+      expect(key_manager.workflow_key_pattern).to eq("#{configuration.namespace}.*")
+    end
+  end
+
+  describe '#succeeded_workflow_key_pattern' do
+    it 'should return correct pattern' do
+      expect(key_manager.succeeded_workflow_key_pattern).to eq("#{configuration.namespace}.*_*_[^0]*")
+    end
+
+    it 'should match completed workflow keys' do
+      completed_key = "#{configuration.namespace}.123_1234567890_1234567900"
+      expect(completed_key).to match(/#{configuration.namespace}\..*_.*_[^0].*/)
+    end
+
+    it 'should not match in-progress workflow keys' do
+      in_progress_key = "#{configuration.namespace}.123_1234567890_0"
+      expect(in_progress_key).not_to match(/#{configuration.namespace}\..*_.*_[^0].*/)
+    end
+  end
+end


### PR DESCRIPTION
###  Summary

- Refactored workflow key management by extracting key generation, lookup, and storage operations into a dedicated KeyManager class.
- No breaking changes - all existing Client methods still work

### Changes

  - New KeyManager class (lib/sidekiq_flow/key_manager.rb): Centralizes all Redis key operations for workflows
    - All methods support optional redis parameter to avoid nested connection pool usage
  - Client refactoring (lib/sidekiq_flow/client.rb):
    - Delegates key operations to KeyManager instance
    - All original methods marked @deprecated and delegate to KeyManager for backward compatibility
  - Add spec/sidekiq_flow/key_manager_spec.rb
