### PR TITLE
Upgrade to ruby 3.4 and modernize front

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Ruby image as a parent image
-FROM ruby:3.3
+FROM ruby:3.4
 
 # Set environment variables to avoid warnings during installation
 ENV DEBIAN_FRONTEND=noninteractive

--- a/README.md
+++ b/README.md
@@ -8,6 +8,27 @@ Workflow runner, inspired by [gush](https://github.com/chaps-io/gush) gem.
 Parallel runner for DAG (directed acyclic graph) defined workflows.
 It uses Sidekiq for scheduling and executing jobs and Redis as workflows storage.
 
+Requires Ruby >= 3.2 (tested through Ruby 3.4).
+
+
+## Web dashboard
+
+SidekiqFlow ships with a small Sinatra app (`SidekiqFlow::Front::App`) for inspecting and managing workflows without needing console access.
+
+Mount it as a Rack app, e.g. in a `config.ru`:
+```ruby
+require 'sidekiq_flow'
+run SidekiqFlow::Front::App
+```
+
+It provides:
+* a searchable, sortable, paginated list of all workflows with their start/succeeded times
+* a per-workflow DAG view rendering the task graph, color-coded by status (pending, enqueued, succeeded, failed, skipped, awaiting_retry)
+* retrying or clearing a task directly from the graph
+* bulk deletion of succeeded workflows
+
+The UI is built with Tailwind CSS (loaded via CDN) and plain JavaScript (ES modules) — no Node toolchain or asset build step required. Assets are served directly by Sinatra/Puma. Graph rendering uses [d3](https://d3js.org/) and [dagre-d3-es](https://github.com/tbo47/dagre-es).
+
 
 ## Workflow definition
 

--- a/lib/sidekiq_flow.rb
+++ b/lib/sidekiq_flow.rb
@@ -18,7 +18,7 @@ require "sidekiq_flow/task_trigger_rules/all_succeeded"
 require "sidekiq_flow/task_trigger_rules/number_succeeded"
 require "sidekiq_flow/front/app"
 require "sidekiq_flow/front/serializers/workflow_serializer"
-require "sidekiq_flow/front/searches/data_table_search"
+require "sidekiq_flow/front/searches/workflows_search"
 require "sidekiq_flow/task_logger"
 
 module SidekiqFlow

--- a/lib/sidekiq_flow.rb
+++ b/lib/sidekiq_flow.rb
@@ -4,8 +4,6 @@ require 'connection_pool'
 require 'redis'
 require 'sidekiq'
 require 'sinatra/base'
-require 'sprockets'
-require 'uglifier'
 
 require "sidekiq_flow/version"
 require "sidekiq_flow/configuration"

--- a/lib/sidekiq_flow/client.rb
+++ b/lib/sidekiq_flow/client.rb
@@ -142,7 +142,7 @@ module SidekiqFlow
         workflow_keys = find_workflow_keys(succeeded_workflow_key_pattern)
         return if workflow_keys.empty?
 
-        workflow_ids = workflow_keys.map { |key| key.match(/#{configuration.namespace}\.(\d+)_/)[1] }
+        workflow_ids = workflow_keys.map { |key| key.match(/#{configuration.namespace}\.([^_]+)_/)[1] }
         timestamp_keys = workflow_ids.flat_map { |id| ["#{timestamp_namespace}.#{id}.start", "#{timestamp_namespace}.#{id}.end"] }
 
         connection_pool.with do |redis|

--- a/lib/sidekiq_flow/front/app.rb
+++ b/lib/sidekiq_flow/front/app.rb
@@ -22,7 +22,7 @@ module SidekiqFlow
       end
 
       get '/workflows' do
-        search = DataTableSearch.new(
+        search = WorkflowsSearch.new(
           params.dig('search', 'value'),
           params.dig('order', '0', 'column').to_i,
           params.dig('order', '0', 'dir'),

--- a/lib/sidekiq_flow/front/app.rb
+++ b/lib/sidekiq_flow/front/app.rb
@@ -2,13 +2,7 @@ module SidekiqFlow
   module Front
     class App < Sinatra::Base
       enable :logging
-      set :server, :thin
-      set :environment, Sprockets::Environment.new(File.dirname(__FILE__))
-
-      environment.append_path 'assets/stylesheets'
-      environment.append_path 'assets/javascripts'
-      environment.js_compressor  = :uglify
-      environment.css_compressor = :scss
+      set :server, :puma
 
       helpers do
         def app_prefix
@@ -16,9 +10,11 @@ module SidekiqFlow
         end
       end
 
-      get %r{/(js|css)/.+} do |asset_type|
-        env['PATH_INFO'].sub!("/#{asset_type}", '')
-        settings.environment.call(env)
+      get %r{/(js|css)/(.+)} do |asset_type, filename|
+        dir = asset_type == 'js' ? 'javascripts' : 'stylesheets'
+        path = File.join(File.dirname(__FILE__), 'assets', dir, filename)
+        halt 404 unless File.file?(path)
+        send_file path
       end
 
       get '/' do
@@ -36,11 +32,12 @@ module SidekiqFlow
         )
         search.execute!
 
-        json(
+        content_type :json
+        {
           recordsTotal: search.input_data_size,
           recordsFiltered: search.filtered_data_size,
           data: search.data
-        )
+        }.to_json
       end
 
       get '/workflow/:id' do |id|

--- a/lib/sidekiq_flow/front/assets/javascripts/graph.js
+++ b/lib/sidekiq_flow/front/assets/javascripts/graph.js
@@ -1,5 +1,5 @@
-import * as d3 from 'https://cdn.jsdelivr.net/npm/d3@7/+esm';
-import * as dagreD3 from 'https://cdn.jsdelivr.net/npm/dagre-d3-es/+esm';
+import * as d3 from 'https://cdn.jsdelivr.net/npm/d3@7.9.0/+esm';
+import * as dagreD3 from 'https://cdn.jsdelivr.net/npm/dagre-d3-es@7.0.14/+esm';
 
 function getWidth(selector) {
   return document.querySelector(selector).getBoundingClientRect().width;

--- a/lib/sidekiq_flow/front/assets/javascripts/graph.js
+++ b/lib/sidekiq_flow/front/assets/javascripts/graph.js
@@ -57,7 +57,7 @@ d3.select(graphInnerContainerSelector).call(dagreD3.render(), graph);
 
 // START: center graph
 var xCenterOffset = (getWidth(graphOuterContainerSelector) - getWidth(graphInnerContainerSelector)) / 2;
-graphInnerContainer.attr("transform", "translate(" + xCenterOffset + ", 20)");
+graphInnerContainer.attr("transform", "translate(" + xCenterOffset + ", 90)");
 graphOuterContainer.attr("height", graph.graph().height + 40)
 // END: center graph
 

--- a/lib/sidekiq_flow/front/assets/javascripts/graph.js
+++ b/lib/sidekiq_flow/front/assets/javascripts/graph.js
@@ -1,66 +1,99 @@
+import * as d3 from 'https://cdn.jsdelivr.net/npm/d3@7/+esm';
+import * as dagreD3 from 'https://cdn.jsdelivr.net/npm/dagre-d3-es/+esm';
+
 function getWidth(selector) {
   return document.querySelector(selector).getBoundingClientRect().width;
 }
 
-$(document).ready(function() {
-  var graphOuterContainerSelector = '#workflow-graph',
-      appPrefix = $('body').data('appPrefix'),
-      graphInnerContainerSelector = graphOuterContainerSelector + ' g',
-      graphNodeSelector = graphInnerContainerSelector + '.node',
-      $taskModal = $('#task-modal'),
-      $taskModalTitle = $taskModal.find('.modal-title'),
-      $taskModalAttrs = $taskModal.find('#task-attrs'),
-      $taskModalRetryBtn = $taskModal.find('#retry-task'),
-      $taskModalClearBtn = $taskModal.find('#clear-task'),
-      graph = new dagreD3.graphlib.Graph();
+var graphOuterContainerSelector = '#workflow-graph',
+    appPrefix = document.body.dataset.appPrefix,
+    graphInnerContainerSelector = graphOuterContainerSelector + ' g',
+    graphNodeSelector = graphInnerContainerSelector + '.node',
+    taskModal = document.querySelector('#task-modal'),
+    taskModalBackdrop = taskModal.querySelector('#task-modal-backdrop'),
+    taskModalPanel = taskModal.querySelector('#task-modal-panel'),
+    taskModalTitle = taskModal.querySelector('.modal-title'),
+    taskModalAttrs = taskModal.querySelector('#task-attrs'),
+    taskModalRetryBtn = taskModal.querySelector('#retry-task'),
+    taskModalClearBtn = taskModal.querySelector('#clear-task'),
+    graph = new dagreD3.graphlib.Graph();
 
-  graph.setGraph({});
-  graph.setDefaultEdgeLabel(function() { return {}; });
+function showModal() {
+  taskModal.classList.remove('hidden');
+  requestAnimationFrame(function() {
+    taskModalBackdrop.classList.remove('opacity-0');
+    taskModalPanel.classList.remove('opacity-0', 'scale-95');
+  });
+}
 
-  workflow.tasks.forEach(function(task) {
-    graph.setNode(task.klass, {label: task.name, class: task.status});
-    task.children.forEach(function(childClass) {
-      graph.setEdge(task.klass, childClass);
+function hideModal() {
+  taskModalBackdrop.classList.add('opacity-0');
+  taskModalPanel.classList.add('opacity-0', 'scale-95');
+  setTimeout(function() { taskModal.classList.add('hidden'); }, 150);
+}
+
+taskModal.querySelectorAll('[data-modal-dismiss]').forEach(function(el) {
+  el.addEventListener('click', hideModal);
+});
+
+graph.setGraph({ranksep: 60, nodesep: 60});
+graph.setDefaultEdgeLabel(function() { return {curve: d3.curveBasis}; });
+
+workflow.tasks.forEach(function(task) {
+  graph.setNode(task.klass, {label: task.name, class: task.status, paddingX: 24});
+  task.children.forEach(function(childClass) {
+    graph.setEdge(task.klass, childClass);
+  });
+});
+
+var graphOuterContainer = d3.select(graphOuterContainerSelector),
+    graphInnerContainer = d3.select(graphInnerContainerSelector),
+    zoom = d3.zoom().on('zoom', function(event) {
+      graphInnerContainer.attr('transform', event.transform);
     });
-  });
+graphOuterContainer.call(zoom);
 
-  var graphOuterContainer = d3.select(graphOuterContainerSelector),
-      graphInnerContainer = d3.select(graphInnerContainerSelector),
-      zoom = d3.zoom().on('zoom', function() {
-        graphInnerContainer.attr('transform', d3.event.transform);
-      });
-  graphOuterContainer.call(zoom);
+d3.select(graphInnerContainerSelector).call(dagreD3.render(), graph);
 
-  d3.select(graphInnerContainerSelector).call(dagreD3.render(), graph);
+// START: center graph
+var xCenterOffset = (getWidth(graphOuterContainerSelector) - getWidth(graphInnerContainerSelector)) / 2;
+graphInnerContainer.attr("transform", "translate(" + xCenterOffset + ", 20)");
+graphOuterContainer.attr("height", graph.graph().height + 40)
+// END: center graph
 
-  // START: center graph
-  var xCenterOffset = (getWidth(graphOuterContainerSelector) - getWidth(graphInnerContainerSelector)) / 2;
-  graphInnerContainer.attr("transform", "translate(" + xCenterOffset + ", 20)");
-  graphOuterContainer.attr("height", graph.graph().height + 40)
-  // END: center graph
+d3.selectAll(graphNodeSelector).each(function(taskClass) {
+  d3.select(this).attr('data-task', JSON.stringify(workflow.tasks.find(function(task) { return task.klass == taskClass; })));
+});
 
-  d3.selectAll(graphNodeSelector).each(function(taskClass) {
-    d3.select(this).attr('data-task', JSON.stringify(workflow.tasks.find(function(task) { return task.klass == taskClass; })));
-  });
-
-  $(graphNodeSelector).click(function() {
-    var task = $(this).data('task');
-    $taskModalTitle.text(task.name);
-    $taskModalAttrs.empty();
+document.querySelectorAll(graphNodeSelector).forEach(function(node) {
+  node.addEventListener('click', function() {
+    var task = JSON.parse(this.getAttribute('data-task'));
+    taskModalTitle.textContent = task.name;
+    taskModalAttrs.innerHTML = '';
     Object.keys(task).forEach(function(key) {
-      value = key == 'params' ? JSON.stringify(task[key]) : task[key];
-      $taskModalAttrs.append($('<p>').text(key + ': ' + value));
+      var value = key == 'params' ? JSON.stringify(task[key]) : task[key];
+      var row = document.createElement('div');
+      row.className = 'flex justify-between gap-4 py-1.5';
+      var label = document.createElement('span');
+      label.className = 'font-medium text-slate-500';
+      label.textContent = key;
+      var val = document.createElement('span');
+      val.className = 'text-right text-slate-900 break-all font-mono text-xs';
+      val.textContent = value;
+      row.appendChild(label);
+      row.appendChild(val);
+      taskModalAttrs.appendChild(row);
     });
-    $taskModal.modal();
-    $taskModalRetryBtn.click(function() {
+    showModal();
+    taskModalRetryBtn.onclick = function() {
       if (confirm('Are you sure you want to retry the task?')) {
-        $.get(appPrefix + '/workflow/' + workflow.id + '/task/' + task.klass + '/retry', function() { location.reload(); });
+        fetch(appPrefix + '/workflow/' + workflow.id + '/task/' + task.klass + '/retry').then(function() { location.reload(); });
       }
-    });
-    $taskModalClearBtn.click(function() {
+    };
+    taskModalClearBtn.onclick = function() {
       if (confirm('Are you sure you want to clear the task?')) {
-        $.get(appPrefix + '/workflow/' + workflow.id + '/task/' + task.klass + '/clear', function() { location.reload(); });
+        fetch(appPrefix + '/workflow/' + workflow.id + '/task/' + task.klass + '/clear').then(function() { location.reload(); });
       }
-    });
+    };
   });
 });

--- a/lib/sidekiq_flow/front/assets/javascripts/graph.js
+++ b/lib/sidekiq_flow/front/assets/javascripts/graph.js
@@ -5,6 +5,10 @@ function getWidth(selector) {
   return document.querySelector(selector).getBoundingClientRect().width;
 }
 
+function getHeight(selector) {
+  return document.querySelector(selector).getBoundingClientRect().height;
+}
+
 var graphOuterContainerSelector = '#workflow-graph',
     appPrefix = document.body.dataset.appPrefix,
     graphInnerContainerSelector = graphOuterContainerSelector + ' g',
@@ -40,7 +44,7 @@ graph.setGraph({ranksep: 60, nodesep: 60});
 graph.setDefaultEdgeLabel(function() { return {curve: d3.curveBasis}; });
 
 workflow.tasks.forEach(function(task) {
-  graph.setNode(task.klass, {label: task.name, class: task.status, paddingX: 24});
+  graph.setNode(task.klass, {label: task.name, class: task.status, paddingX: 20});
   task.children.forEach(function(childClass) {
     graph.setEdge(task.klass, childClass);
   });
@@ -55,11 +59,17 @@ graphOuterContainer.call(zoom);
 
 d3.select(graphInnerContainerSelector).call(dagreD3.render(), graph);
 
-// START: center graph
-var xCenterOffset = (getWidth(graphOuterContainerSelector) - getWidth(graphInnerContainerSelector)) / 2;
-graphInnerContainer.attr("transform", "translate(" + xCenterOffset + ", 90)");
-graphOuterContainer.attr("height", graph.graph().height + 40)
-// END: center graph
+// START: fit graph to container
+var outerWidth = getWidth(graphOuterContainerSelector),
+    outerHeight = getHeight(graphOuterContainerSelector),
+    graphWidth = graph.graph().width,
+    graphHeight = graph.graph().height,
+    fitPadding = 40,
+    fitScale = Math.min(1, (outerWidth - fitPadding * 2) / graphWidth, (outerHeight - fitPadding * 2) / graphHeight),
+    fitTranslateX = (outerWidth - graphWidth * fitScale) / 2,
+    fitTranslateY = (outerHeight - graphHeight * fitScale) / 2;
+graphOuterContainer.call(zoom.transform, d3.zoomIdentity.translate(fitTranslateX, fitTranslateY).scale(fitScale));
+// END: fit graph to container
 
 d3.selectAll(graphNodeSelector).each(function(taskClass) {
   d3.select(this).attr('data-task', JSON.stringify(workflow.tasks.find(function(task) { return task.klass == taskClass; })));

--- a/lib/sidekiq_flow/front/assets/javascripts/workflows_table.js
+++ b/lib/sidekiq_flow/front/assets/javascripts/workflows_table.js
@@ -1,0 +1,97 @@
+document.addEventListener('DOMContentLoaded', function() {
+  var appPrefix = document.body.dataset.appPrefix;
+  var tableBody = document.querySelector('#workflows-table tbody');
+  var searchInput = document.querySelector('#workflows-search');
+  var pageInfo = document.querySelector('#workflows-page-info');
+  var prevBtn = document.querySelector('#workflows-prev');
+  var nextBtn = document.querySelector('#workflows-next');
+  var headers = document.querySelectorAll('#workflows-table th[data-sort]');
+
+  var state = {start: 0, length: 25, orderColumn: 1, orderDir: 'desc', search: ''};
+
+  function updateSortIndicators() {
+    headers.forEach(function(h) {
+      h.removeAttribute('data-dir');
+      if (parseInt(h.dataset.sort, 10) === state.orderColumn) {
+        h.setAttribute('data-dir', state.orderDir);
+      }
+    });
+  }
+
+  function load() {
+    var url = new URL(appPrefix + '/workflows', window.location.origin);
+    url.searchParams.set('start', state.start);
+    url.searchParams.set('length', state.length);
+    url.searchParams.set('search[value]', state.search);
+    url.searchParams.set('order[0][column]', state.orderColumn);
+    url.searchParams.set('order[0][dir]', state.orderDir);
+
+    fetch(url).then(function(res) { return res.json(); }).then(function(json) {
+      tableBody.innerHTML = '';
+
+      if (json.data.length === 0) {
+        var emptyRow = document.createElement('tr');
+        var emptyCell = document.createElement('td');
+        emptyCell.colSpan = 4;
+        emptyCell.className = 'px-4 py-8 text-center text-slate-400';
+        emptyCell.textContent = 'No workflows found.';
+        emptyRow.appendChild(emptyCell);
+        tableBody.appendChild(emptyRow);
+      }
+
+      json.data.forEach(function(row, rowIndex) {
+        var tr = document.createElement('tr');
+        tr.className = (rowIndex % 2 === 0 ? 'bg-white' : 'bg-slate-50') + ' hover:bg-indigo-50 transition-colors';
+        row.forEach(function(cell, i) {
+          var td = document.createElement('td');
+          td.className = i === row.length - 1 ? 'px-4 py-1.5 text-right' : 'px-4 py-1.5 text-slate-700';
+          td.innerHTML = cell;
+          tr.appendChild(td);
+        });
+        tableBody.appendChild(tr);
+      });
+
+      var from = json.recordsFiltered === 0 ? 0 : state.start + 1;
+      var to = Math.min(state.start + state.length, json.recordsFiltered);
+      pageInfo.textContent = 'Showing ' + from + '-' + to + ' of ' + json.recordsFiltered;
+      prevBtn.disabled = state.start === 0;
+      nextBtn.disabled = state.start + state.length >= json.recordsFiltered;
+      updateSortIndicators();
+    });
+  }
+
+  headers.forEach(function(h) {
+    h.addEventListener('click', function() {
+      var col = parseInt(h.dataset.sort, 10);
+      if (state.orderColumn === col) {
+        state.orderDir = state.orderDir === 'asc' ? 'desc' : 'asc';
+      } else {
+        state.orderColumn = col;
+        state.orderDir = 'asc';
+      }
+      state.start = 0;
+      load();
+    });
+  });
+
+  var searchTimeout;
+  searchInput.addEventListener('input', function() {
+    clearTimeout(searchTimeout);
+    searchTimeout = setTimeout(function() {
+      state.search = searchInput.value;
+      state.start = 0;
+      load();
+    }, 250);
+  });
+
+  prevBtn.addEventListener('click', function() {
+    state.start = Math.max(0, state.start - state.length);
+    load();
+  });
+  nextBtn.addEventListener('click', function() {
+    state.start += state.length;
+    load();
+  });
+
+  load();
+});

--- a/lib/sidekiq_flow/front/assets/stylesheets/app.css
+++ b/lib/sidekiq_flow/front/assets/stylesheets/app.css
@@ -1,59 +1,74 @@
-#main-container {
-  padding-top: 20px;
-
-  h1 {
-    margin-bottom: 2rem;
-  }
-}
-
 svg#workflow-graph {
-  border: 1px solid gray;
-  overflow: hidden;
-  height: 70vh;
-  padding-top: 10px;
-
-  g.node {
-    stroke: black;
-    cursor: pointer;
-  }
-
-  g.node.pending {
-    fill: white;
-  }
-
-  g.node.succeeded {
-    fill: green;
-  }
-
-  g.node.failed {
-    fill: red;
-  }
-
-  g.node.enqueued {
-    fill: silver;
-  }
-
-  g.node.skipped {
-    fill: pink;
-  }
-
-  g.node.awaiting_retry {
-    fill: orange;
-  }
-
-  g.edgePath {
-    stroke: black;
-  }
-
-  text {
-    fill: black;
-  }
+  cursor: grab;
+  background-image: radial-gradient(circle, #cbd5e1 1px, transparent 1px);
+  background-size: 18px 18px;
 }
 
-#workflows-table {
-  th.no-sort {
-    background-image: none;
-    pointer-events: none;
-    cursor: default;
-  }
+svg#workflow-graph:active {
+  cursor: grabbing;
+}
+
+svg#workflow-graph .node rect,
+svg#workflow-graph .node polygon {
+  rx: 6px;
+  ry: 6px;
+  stroke-width: 1px;
+  filter: drop-shadow(0 1px 2px rgb(15 23 42 / 0.15));
+  transition: filter 0.15s ease;
+}
+
+svg#workflow-graph .node:hover rect,
+svg#workflow-graph .node:hover polygon {
+  filter: drop-shadow(0 2px 6px rgb(15 23 42 / 0.25)) brightness(0.96);
+}
+
+svg#workflow-graph g.node {
+  stroke: black;
+  cursor: pointer;
+}
+
+svg#workflow-graph g.node.pending {
+  fill: white;
+}
+
+svg#workflow-graph g.node.succeeded {
+  fill: mediumseagreen;
+}
+
+svg#workflow-graph g.node.failed {
+  fill: #ef4444;
+}
+
+svg#workflow-graph g.node.enqueued {
+  fill: silver;
+}
+
+svg#workflow-graph g.node.skipped {
+  fill: pink;
+}
+
+svg#workflow-graph g.node.awaiting_retry {
+  fill: sandybrown;
+}
+
+svg#workflow-graph g.edgePath path {
+  stroke: #94a3b8;
+  stroke-width: 1.5px;
+}
+
+svg#workflow-graph .edgePath marker path {
+  fill: #94a3b8;
+  stroke: none;
+}
+
+svg#workflow-graph text {
+  fill: black;
+}
+
+#workflows-table th[data-dir="asc"]::after {
+  content: ' \25B2';
+}
+
+#workflows-table th[data-dir="desc"]::after {
+  content: ' \25BC';
 }

--- a/lib/sidekiq_flow/front/searches/data_table_search.rb
+++ b/lib/sidekiq_flow/front/searches/data_table_search.rb
@@ -34,10 +34,14 @@ module SidekiqFlow
         # decorating
         @data.map! do |workflow_id, workflow_started_at, workflow_succeeded_at|
           [
-            "<a href=\"#{app_prefix}/workflow/#{workflow_id}\">#{workflow_id}</a>",
+            "<a class='font-mono text-indigo-600 hover:text-indigo-500 hover:underline' href=\"#{app_prefix}/workflow/#{workflow_id}\">#{workflow_id}</a>",
             workflow_started_at,
             workflow_succeeded_at,
-            "<a href=\"#{app_prefix}/workflow/#{workflow_id}/destroy\" onclick=\"return confirm('Are you sure?')\"><i class='fas fa-trash'></i></a>"
+            "<a class='inline-flex items-center justify-center rounded-full p-1.5 text-slate-400 hover:bg-red-50 hover:text-red-600 transition-colors' " \
+              "href=\"#{app_prefix}/workflow/#{workflow_id}/destroy\" onclick=\"return confirm('Are you sure?')\" aria-label='Destroy workflow'>" \
+              "<svg class='w-4 h-4' viewBox='0 0 20 20' fill='currentColor' aria-hidden='true'>" \
+              "<path fill-rule='evenodd' d='M8.75 1A2.75 2.75 0 0 0 6 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 1 0 .23 1.482l.149-.022.841 10.518A2.75 2.75 0 0 0 7.596 19h4.807a2.75 2.75 0 0 0 2.742-2.53l.841-10.52.149.023a.75.75 0 0 0 .23-1.482A41.03 41.03 0 0 0 14 4.193V3.75A2.75 2.75 0 0 0 11.25 1h-2.5ZM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4ZM8.58 7.72a.75.75 0 0 0-1.5.06l.3 7.5a.75.75 0 1 0 1.5-.06l-.3-7.5Zm4.34.06a.75.75 0 1 0-1.5-.06l-.3 7.5a.75.75 0 1 0 1.5.06l.3-7.5Z' clip-rule='evenodd' />" \
+              '</svg></a>'
           ]
         end
       end

--- a/lib/sidekiq_flow/front/searches/workflows_search.rb
+++ b/lib/sidekiq_flow/front/searches/workflows_search.rb
@@ -1,6 +1,6 @@
 module SidekiqFlow
   module Front
-    class DataTableSearch
+    class WorkflowsSearch
       attr_reader :input_data_size, :filtered_data_size, :data
 
       def initialize(value, order_column_index, order_dir, start_index, page_size, app_prefix)

--- a/lib/sidekiq_flow/front/views/index.erb
+++ b/lib/sidekiq_flow/front/views/index.erb
@@ -1,27 +1,47 @@
-<p>
-  <a class='btn btn-danger float-right' href="<%= app_prefix %>/workflows/succeeded/destroy" onclick="return confirm('Are you sure?')">
-    <i class='fas fa-trash'></i>&nbsp;Destroy succeeded workflows
+<div class="flex flex-wrap items-center justify-between gap-4 mb-6">
+  <div>
+    <h1 class="text-2xl font-bold tracking-tight text-slate-900">Workflows</h1>
+    <p class="mt-1 text-sm text-slate-500">Monitor and manage your Sidekiq workflow runs.</p>
+  </div>
+  <a class="inline-flex items-center gap-2 rounded-lg bg-red-600 px-3.5 py-2 text-sm font-medium text-white shadow-sm hover:bg-red-500 transition-colors focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2" href="<%= app_prefix %>/workflows/succeeded/destroy" onclick="return confirm('Are you sure?')">
+    <svg class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <path fill-rule="evenodd" d="M8.75 1A2.75 2.75 0 0 0 6 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 1 0 .23 1.482l.149-.022.841 10.518A2.75 2.75 0 0 0 7.596 19h4.807a2.75 2.75 0 0 0 2.742-2.53l.841-10.52.149.023a.75.75 0 0 0 .23-1.482A41.03 41.03 0 0 0 14 4.193V3.75A2.75 2.75 0 0 0 11.25 1h-2.5ZM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4ZM8.58 7.72a.75.75 0 0 0-1.5.06l.3 7.5a.75.75 0 1 0 1.5-.06l-.3-7.5Zm4.34.06a.75.75 0 1 0-1.5-.06l-.3 7.5a.75.75 0 1 0 1.5.06l.3-7.5Z" clip-rule="evenodd" />
+    </svg>
+    Destroy succeeded
   </a>
-</p>
+</div>
 
-<h1>Workflows</h1>
+<div class="rounded-xl border border-slate-200 bg-white shadow-sm">
+  <div class="border-b border-slate-200 p-4">
+    <div class="relative max-w-xs">
+      <svg class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fill-rule="evenodd" d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11ZM2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9Z" clip-rule="evenodd" />
+      </svg>
+      <input id="workflows-search" type="text" placeholder="Search workflows..." class="w-full rounded-lg border border-slate-300 pl-9 pr-3 py-2 text-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
+    </div>
+  </div>
 
-<table id='workflows-table' class='display' style='width:100%'>
-  <thead>
-    <tr>
-      <th>ID</th>
-      <th>Started at</th>
-      <th>Succeeded at</th>
-      <th class='no-sort'>#</th>
-    </tr>
-  </thead>
-</table>
+  <div class="overflow-x-auto">
+    <table id="workflows-table" class="w-full text-sm text-left">
+      <thead class="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-500">
+        <tr>
+          <th data-sort="0" class="px-4 py-2 cursor-pointer select-none hover:text-slate-700">ID</th>
+          <th data-sort="1" class="px-4 py-2 cursor-pointer select-none hover:text-slate-700">Started at</th>
+          <th data-sort="2" class="px-4 py-2 cursor-pointer select-none hover:text-slate-700">Succeeded at</th>
+          <th class="px-4 py-2 text-right">Actions</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-slate-100"></tbody>
+    </table>
+  </div>
 
-<script>
-  $('#workflows-table').DataTable({
-    order: [[1, 'desc']],
-    processing: true,
-    serverSide: true,
-    ajax: "<%= app_prefix %>/workflows"
-  });
-</script>
+  <div class="flex items-center justify-between border-t border-slate-200 px-4 py-2 text-sm text-slate-500">
+    <span id="workflows-page-info"></span>
+    <div class="flex gap-2">
+      <button id="workflows-prev" type="button" class="rounded-lg border border-slate-300 px-3 py-1.5 text-slate-700 hover:bg-slate-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors">Previous</button>
+      <button id="workflows-next" type="button" class="rounded-lg border border-slate-300 px-3 py-1.5 text-slate-700 hover:bg-slate-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors">Next</button>
+    </div>
+  </div>
+</div>
+
+<script src="<%= app_prefix %>/js/workflows_table.js"></script>

--- a/lib/sidekiq_flow/front/views/layout.erb
+++ b/lib/sidekiq_flow/front/views/layout.erb
@@ -1,31 +1,23 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="h-full bg-slate-50">
   <head>
     <meta charset="utf8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/jquery.dataTables.min.css">
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css">
+    <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="<%= app_prefix %>/css/app.css">
-    <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/js/bootstrap.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.13.0/d3.min.js"></script>
-    <script src="https://dagrejs.github.io/project/dagre-d3/latest/dagre-d3.min.js"></script>
-    <script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
     <title>
       SidekiqFlow
     </title>
   </head>
-  <body data-app-prefix=<%= app_prefix %>>
-    <nav class="navbar navbar-light bg-light">
-      <a class="navbar-brand" href="<%= app_prefix %>/">SidekiqFlow</a>
-    </nav>
-    <div id="main-container" class="container">
-      <div class="row">
-        <div class="col">
-          <%= yield %>
-        </div>
+  <body class="h-full text-slate-900 antialiased" data-app-prefix=<%= app_prefix %>>
+    <nav class="bg-white border-b border-slate-200">
+      <div class="max-w-6xl mx-auto px-4 sm:px-6 py-4 flex items-center gap-2.5">
+        <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-indigo-600 text-xs font-bold text-white">SF</span>
+        <a class="text-lg font-semibold tracking-tight text-slate-900 hover:text-indigo-600 transition-colors" href="<%= app_prefix %>/">SidekiqFlow</a>
       </div>
-    </div>
+    </nav>
+    <main class="max-w-6xl mx-auto px-4 sm:px-6 py-8">
+      <%= yield %>
+    </main>
   </body>
 </html>

--- a/lib/sidekiq_flow/front/views/layout.erb
+++ b/lib/sidekiq_flow/front/views/layout.erb
@@ -11,12 +11,12 @@
   </head>
   <body class="h-full text-slate-900 antialiased" data-app-prefix=<%= app_prefix %>>
     <nav class="bg-white border-b border-slate-200">
-      <div class="max-w-6xl mx-auto px-4 sm:px-6 py-4 flex items-center gap-2.5">
+      <div class="w-[90%] mx-auto py-4 flex items-center gap-2.5">
         <span class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-indigo-600 text-xs font-bold text-white">SF</span>
         <a class="text-lg font-semibold tracking-tight text-slate-900 hover:text-indigo-600 transition-colors" href="<%= app_prefix %>/">SidekiqFlow</a>
       </div>
     </nav>
-    <main class="max-w-6xl mx-auto px-4 sm:px-6 py-8">
+    <main class="w-[90%] mx-auto py-8">
       <%= yield %>
     </main>
   </body>

--- a/lib/sidekiq_flow/front/views/workflow.erb
+++ b/lib/sidekiq_flow/front/views/workflow.erb
@@ -1,27 +1,42 @@
-<script src="<%= app_prefix %>/js/graph.js"></script>
+<script type="module" src="<%= app_prefix %>/js/graph.js"></script>
 
-<h1>Workflow <%= @workflow.id %></h1>
-<svg id='workflow-graph' width='100%' height='400'>
-  <g class='viewport'></g>
-</svg>
+<div class="mb-6 flex items-center gap-3">
+  <a href="<%= app_prefix %>/" class="rounded-lg p-1.5 text-slate-400 hover:bg-slate-100 hover:text-slate-600 transition-colors" aria-label="Back to workflows">
+    <svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
+    </svg>
+  </a>
+  <h1 class="text-2xl font-bold tracking-tight text-slate-900">
+    Workflow <span class="font-mono text-indigo-600"><%= @workflow.id %></span>
+  </h1>
+</div>
 
-<div id='task-modal' class='modal' tabindex='-1' role='dialog'>
-  <div class='modal-dialog' role='document'>
-    <div class='modal-content'>
-      <div class="modal-header">
-        <h5 class='modal-title'></h5>
-        <button type='button' class='close' data-dismiss='modal' aria-label='Close'>
-          <span aria-hidden='true'>&times;</span>
-        </button>
+<div class="rounded-xl border border-slate-200 bg-white shadow-sm p-4">
+  <svg id='workflow-graph' class="w-full h-[70vh] rounded-lg border border-slate-200 bg-slate-50" height='400'>
+    <g class='viewport'></g>
+  </svg>
+</div>
+
+<div id='task-modal' class='fixed inset-0 z-50 hidden' role='dialog' aria-modal='true'>
+  <div id='task-modal-backdrop' class='fixed inset-0 bg-slate-900/40 backdrop-blur-sm opacity-0 transition-opacity duration-150 ease-out' data-modal-dismiss></div>
+  <div id='task-modal-panel' class='relative mx-auto mt-24 w-full max-w-lg scale-95 rounded-xl bg-white opacity-0 shadow-2xl ring-1 ring-slate-200 transition-all duration-150 ease-out'>
+    <div class='flex items-center justify-between border-b border-slate-200 px-5 py-4'>
+      <h5 class='modal-title text-base font-semibold text-slate-900'></h5>
+      <button type='button' class='rounded-md p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-600 transition-colors' data-modal-dismiss aria-label='Close'>
+        <svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
+        </svg>
+      </button>
+    </div>
+    <div class='px-5 py-4'>
+      <div id='task-attrs' class="divide-y divide-slate-100 text-sm"></div>
+      <div class="mt-5 flex gap-2">
+        <button id='retry-task' type='button' class='inline-flex items-center gap-1.5 rounded-lg bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-500 transition-colors'>Retry task</button>
+        <button id='clear-task' type='button' class='inline-flex items-center gap-1.5 rounded-lg border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50 transition-colors'>Clear task</button>
       </div>
-      <div class='modal-body'>
-        <div id='task-attrs'></div>
-        <button id='retry-task' type='button' class='btn btn-info'>Retry task</button>
-        <button id='clear-task' type='button' class='btn btn-info'>Clear task</button>
-      </div>
-      <div class='modal-footer'>
-        <button type='button' class='btn btn-secondary' data-dismiss='modal'>Close</button>
-      </div>
+    </div>
+    <div class='flex justify-end border-t border-slate-200 px-5 py-3'>
+      <button type='button' class='rounded-lg px-3 py-1.5 text-sm text-slate-500 hover:bg-slate-100 transition-colors' data-modal-dismiss>Close</button>
     </div>
   </div>
 </div>

--- a/lib/sidekiq_flow/version.rb
+++ b/lib/sidekiq_flow/version.rb
@@ -1,3 +1,3 @@
 module SidekiqFlow
-  VERSION = "0.3.47"
+  VERSION = "0.3.48"
 end

--- a/lib/sidekiq_flow/worker.rb
+++ b/lib/sidekiq_flow/worker.rb
@@ -73,6 +73,9 @@ module SidekiqFlow
           begin
             perform(child_task.workflow_id, child_class)
           rescue StandardError
+            # perform() re-fetches and mutates its own Task instance internally, so child_task here is
+            # stale (still 'pending') - re-fetch to see the status perform_task actually persisted.
+            child_task = Client.find_task(child_task.workflow_id, child_class)
             Client.enqueue_task(child_task, (Time.now + DEFAULT_RETRY_DELAY).to_i) if child_task.awaiting_retry?
           end
         else

--- a/sidekiq_flow.gemspec
+++ b/sidekiq_flow.gemspec
@@ -36,9 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "connection_pool"
   spec.add_dependency "activesupport"
   spec.add_runtime_dependency "sinatra"
-  spec.add_runtime_dependency "thin"
-  spec.add_runtime_dependency "sprockets"
-  spec.add_runtime_dependency "uglifier"
+  spec.add_runtime_dependency "puma"
   spec.add_runtime_dependency "timecop"
 
   spec.add_development_dependency "bundler"
@@ -46,4 +44,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "byebug"
+  spec.add_development_dependency "rackup"
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -282,17 +282,17 @@ RSpec.describe 'workflow' do
         SidekiqFlow::Client.start_workflow(workflow)
 
         SidekiqFlow::Worker.perform_one
-        # Task 1 succeed, which perform task 2 and enqueue task 3.
-        # Task 2 raise a retry and is enqueued.
+        # Task 1 succeed, which performs task 2 inline (fails, retry gets scheduled) and enqueues task 3.
         expect(task_states(workflow)).to match_array([
-                                                       'TestTask1 - succeeded', 'TestTask2 - awaiting_retry', 'TestTask3 - enqueued', 'TestTask4 - pending'
+                                                       'TestTask1 - succeeded', 'TestTask2 - enqueued', 'TestTask3 - enqueued', 'TestTask4 - pending'
                                                      ])
 
-        SidekiqFlow::Worker.perform_one
-
-        # Task 3 succeed, which cannot inline task 4 as it is waiting for task 2.
+        # Task 2's scheduled retry runs next (it was pushed before task 3's job) and fails again.
+        expect do
+          SidekiqFlow::Worker.perform_one
+        end.to raise_error(RuntimeError)
         expect(task_states(workflow)).to match_array([
-                                                       'TestTask1 - succeeded', 'TestTask2 - awaiting_retry', 'TestTask3 - succeeded', 'TestTask4 - pending'
+                                                       'TestTask1 - succeeded', 'TestTask2 - awaiting_retry', 'TestTask3 - enqueued', 'TestTask4 - pending'
                                                      ])
 
         allow_any_instance_of(TestTask2).to receive(:perform).and_return(true)
@@ -302,8 +302,8 @@ RSpec.describe 'workflow' do
         # start task
         SidekiqFlow::Client.start_task(workflow.id, 'TestTask2')
 
-        SidekiqFlow::Worker.perform_one
-        # Task 2 succeed, which perform task 4.
+        SidekiqFlow::Worker.drain
+        # Task 3 (already enqueued) and task 2 (restarted) both succeed, which performs task 4 inline.
         expect(task_states(workflow)).to match_array([
                                                        'TestTask1 - succeeded', 'TestTask2 - succeeded', 'TestTask3 - succeeded', 'TestTask4 - succeeded'
                                                      ])

--- a/spec/sidekiq_flow/front/searches/workflows_search_spec.rb
+++ b/spec/sidekiq_flow/front/searches/workflows_search_spec.rb
@@ -1,5 +1,5 @@
 module SidekiqFlow::Front
-  RSpec.describe DataTableSearch do
+  RSpec.describe WorkflowsSearch do
     let(:query_string) {
       "/workflows?draw=2&columns%5B0%5D%5Bdata%5D=0&columns%5B0%5D%5Bname%5D=&columns%5B0%5D%5Bsearchable%5D=true&columns%5B0%5D%5Borderable%5D=true&columns%5B0%5D%5Bsearch%5D%5Bvalue%5D=&columns%5B0%5D%5Bsearch%5D%5Bregex%5D=false&columns%5B1%5D%5Bdata%5D=1&columns%5B1%5D%5Bname%5D=&columns%5B1%5D%5Bsearchable%5D=true&columns%5B1%5D%5Borderable%5D=true&columns%5B1%5D%5Bsearch%5D%5Bvalue%5D=&columns%5B1%5D%5Bsearch%5D%5Bregex%5D=false&columns%5B2%5D%5Bdata%5D=2&columns%5B2%5D%5Bname%5D=&columns%5B2%5D%5Bsearchable%5D=true&columns%5B2%5D%5Borderable%5D=true&columns%5B2%5D%5Bsearch%5D%5Bvalue%5D=&columns%5B2%5D%5Bsearch%5D%5Bregex%5D=false&columns%5B3%5D%5Bdata%5D=3&columns%5B3%5D%5Bname%5D=&columns%5B3%5D%5Bsearchable%5D=true&columns%5B3%5D%5Borderable%5D=true&columns%5B3%5D%5Bsearch%5D%5Bvalue%5D=&columns%5B3%5D%5Bsearch%5D%5Bregex%5D=false&order%5B0%5D%5Bcolumn%5D=1&order%5B0%5D%5Bdir%5D=desc&start=0&length=100&search%5Bvalue%5D=&search%5Bregex%5D=false&_=1547470813274"
     }
@@ -8,7 +8,7 @@ module SidekiqFlow::Front
     describe '#initialize' do
       it 'does not raise an error on nil search value' do
         expect {
-          search = DataTableSearch.new(
+          search = WorkflowsSearch.new(
             params.dig('search', 'value'),
             params.dig('order', '0', 'column').to_i,
             params.dig('order', '0', 'dir'),


### PR DESCRIPTION
### Summary

- Bump Ruby to 3.4: update Dockerfile to ruby:3.4
- Modernize the dashboard: replace Bootstrap 4 / jQuery / Font Awesome / DataTables with Tailwind CSS (CDN) and vanilla JS
- Rewrite graph.js as an ES module, drop jQuery, and upgrade the rendering stack from d3 v4 + unmaintained dagre-d3 to d3 v7 + the actively-maintained dagre-d3-es.
- Remove the asset pipeline: drop Sprockets/Uglifier/Sass, which are unnecessary
- Fix misc bugs
  - Switch the app server from thin to puma
  - Replace Sinatra's removed json helper with content_type :json + .to_json
  - Fix Client#destroy_succeeded_workflows, which assumed numeric-only workflow IDs
  
### Screenshots

<img width="1346" height="1019" alt="Screenshot 2026-07-31 at 16 11 23" src="https://github.com/user-attachments/assets/e3e97e72-de51-4435-ae34-67be8ab938c0" />
<img width="1343" height="1189" alt="Screenshot 2026-07-31 at 16 11 51" src="https://github.com/user-attachments/assets/70a57013-72d1-4909-badf-0049763068fc" />
<img width="1275" height="1162" alt="Screenshot 2026-07-31 at 16 13 18" src="https://github.com/user-attachments/assets/5034db3c-6a1a-4d0e-9af1-452a47b68d28" />
